### PR TITLE
Add `stillImageSource` option in config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
 
 ### Config.json Example
 
-	{
+    {
       "platform": "Camera-ffmpeg",
       "cameras": [
         {
           "name": "Camera Name",
           "videoConfig": {
           	"source": "-re -i rtsp://myfancy_rtsp_stream",
+            "stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg"
           	"maxStreams": 2,
           	"maxWidth": 1280,
           	"maxHeight": 720,
@@ -27,3 +28,5 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
         }
       ]
     }
+
+Incidentally, check [iSpyConnect's camera database](https://www.ispyconnect.com/sources.aspx) to find likely protocols and URLs to try with your camera.

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -20,6 +20,7 @@ function FFMPEG(hap, ffmpegOpt) {
   }
 
   this.ffmpegSource = ffmpegOpt.source;
+  this.ffmpegImageSource = ffmpegOpt.stillImageSource;
 
   this.services = [];
   this.streamControllers = [];
@@ -122,7 +123,8 @@ FFMPEG.prototype.handleCloseConnection = function(connectionID) {
 
 FFMPEG.prototype.handleSnapshotRequest = function(request, callback) {
   let resolution = request.width + 'x' + request.height;
-  let ffmpeg = spawn('ffmpeg', (this.ffmpegSource + ' -t 1 -s '+ resolution + ' -f image2 -').split(' '), {env: process.env});
+  var imageSource = this.ffmpegImageSource !== undefined ? this.ffmpegImageSource : this.ffmpegSource;
+  let ffmpeg = spawn('ffmpeg', (imageSource + ' -t 1 -s '+ resolution + ' -f image2 -').split(' '), {env: process.env});
   var imageBuffer = Buffer(0);
 
   ffmpeg.stdout.on('data', function(data) {


### PR DESCRIPTION
Allows for very fast snapshot grabs on certain cameras (e.g. my Foscams) which speeds up UI timeliness a lot.