### PR TITLE
Support for storing snapshots into your google drive account.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,39 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
       ]
     }
 
+* Optional camera videoConfig vcodec, if your running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option.
+
+{
+  "platform": "Camera-ffmpeg",
+  "cameras": [
+    {
+      "name": "Camera Name",
+      "videoConfig": {
+        "source": "-re -i rtsp://myfancy_rtsp_stream",
+        "stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg",
+        "maxStreams": 2,
+        "maxWidth": 1280,
+        "maxHeight": 720,
+        "maxFPS": 30,
+        "vcodec": "h264_omx"
+      }
+    }
+  ]
+}
+
+
+## Google Drive configuration
+
+1. For the setup of Google Drive, please for the Google Drive Quickstart for Node.js instructions from here except for these changes.
+
+https://developers.google.com/drive/v3/web/quickstart/nodejs
+
+* Step 1-h the working directory should be .homebridge directory
+* Skip Step 2 and 3
+* And in step 4, use the quickstart.js included in the plugin itself.  And to do this you need to run the command from the plugin directory.
+
 ## Tested configurations
 
 We have started collecting tested configurations in the wiki, so please before raising an issue with your configuration, please check the [wiki](https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki).  Also if you a working configuration that you would like to share, please add it to the [wiki](https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki).
 
 https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki
-

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
 }
 
 
-## Google Drive configuration
+## Google Drive configuration for storage of snapshots
 
 1. For the setup of Google Drive, please for the Google Drive Quickstart for Node.js instructions from here except for these changes.
 
@@ -58,7 +58,9 @@ https://developers.google.com/drive/v3/web/quickstart/nodejs
 
 * Step 1-h the working directory should be .homebridge directory
 * Skip Step 2 and 3
-* And in step 4, use the quickstart.js included in the plugin itself.  And to do this you need to run the command from the plugin directory.
+* And in step 4, use the quickstart.js included in the plugin itself.  And to do this you need to run the command from the plugin directory.  Then just follows steps a to c
+
+
 
 ## Tested configurations
 

--- a/README.md
+++ b/README.md
@@ -53,16 +53,16 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
 
 ## Google Drive configuration for storage of snapshots
 
-* For the setup of Google Drive, please for the Google Drive Quickstart for Node.js instructions from here except for these changes.
+* For the setup of Google Drive, please follow the Google Drive Quickstart for Node.js instructions from here except for these changes.
 
 https://developers.google.com/drive/v3/web/quickstart/nodejs
 
-* In Step 1-h the working directory should be .homebridge directory
+* In Step 1-h the working directory should be the .homebridge directory
 * Skip Step 2 and 3
 * And in step 4, use the quickstart.js included in the plugin itself.  And to do this you need to run the command from the plugin directory.  Then just follow steps a to c
 
 ## Tested configurations
 
-We have started collecting tested configurations in the wiki, so please before raising an issue with your configuration, please check the [wiki](https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki).  Also if you a working configuration that you would like to share, please add it to the [wiki](https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki).
+We have started collecting tested configurations in the wiki, so please before raising an issue with your configuration, please check the [wiki](https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki).  Also if you have a working configuration that you would like to share, please add it to the [wiki](https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki).
 
 https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki

--- a/README.md
+++ b/README.md
@@ -31,23 +31,23 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
 
 * Optional camera videoConfig vcodec, if your running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option.
 ``
+{
+  "platform": "Camera-ffmpeg",
+  "cameras": [
     {
-      "platform": "Camera-ffmpeg",
-      "cameras": [
-        {
-          "name": "Camera Name",
-          "videoConfig": {
-          	"source": "-re -i rtsp://myfancy_rtsp_stream",
-            "stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg",
-          	"maxStreams": 2,
-          	"maxWidth": 1280,
-          	"maxHeight": 720,
-          	"maxFPS": 30,
-          	"vcodec": "h264_omx"            
-          }
-        }
-      ]
+      "name": "Camera Name",
+      "videoConfig": {
+      	"source": "-re -i rtsp://myfancy_rtsp_stream",
+        "stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg",
+      	"maxStreams": 2,
+      	"maxWidth": 1280,
+      	"maxHeight": 720,
+      	"maxFPS": 30,
+      	"vcodec": "h264_omx"            
+      }
     }
+  ]
+}
 ``
 
 ## Google Drive configuration for storage of snapshots

--- a/README.md
+++ b/README.md
@@ -30,14 +30,11 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
     }
 
 * Optional camera videoConfig vcodec, if your running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option.
-<<<<<<< HEAD
-``
+
+```
 {
   "platform": "Camera-ffmpeg",
   "cameras": [
-=======
-```
->>>>>>> origin/master
     {
       "name": "Camera Name",
       "videoConfig": {
@@ -50,13 +47,9 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
       	"vcodec": "h264_omx"            
       }
     }
-<<<<<<< HEAD
   ]
 }
-``
-=======
 ```
->>>>>>> origin/master
 
 ## Google Drive configuration for storage of snapshots
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
       ]
     }
 
-* Optional camera videoConfig vcodec, if your running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option.
+* Optional parameter vcodec, if your running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option.
 
 ```
 {

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
     }
 
 * Optional camera videoConfig vcodec, if your running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option.
-
+``
     {
       "platform": "Camera-ffmpeg",
       "cameras": [
@@ -48,7 +48,7 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
         }
       ]
     }
-
+``
 
 ## Google Drive configuration for storage of snapshots
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,34 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
 }
 ```
 
-## Google Drive configuration for storage of snapshots
+## Uploading to Google Drive of Still Images ( Snapshots )
+
+This feature will automatically load every snapshot taken to Google Drive, so you look at these later.  This is very useful if you have motion sensor in the same room as the camera, as it will take a snapshot of whatever caused the motion sensor to trigger, and store the image on Google Drive and create a Picture Notification on your iOS device.
+
+To enable this feature, please add a new config option "uploader", and follow the steps below.
+
+* Add the option "uploader" to your config.json i.e.
+
+```
+{
+  "platform": "Camera-ffmpeg",
+  "cameras": [
+    {
+      "name": "Camera Name",
+      "uploader": true,
+      "videoConfig": {
+      	"source": "-re -i rtsp://myfancy_rtsp_stream",
+        "stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg",
+      	"maxStreams": 2,
+      	"maxWidth": 1280,
+      	"maxHeight": 720,
+      	"maxFPS": 30,
+      	"vcodec": "h264_omx"            
+      }
+    }
+  ]
+}
+```
 
 * For the setup of Google Drive, please follow the Google Drive Quickstart for Node.js instructions from here except for these changes.
 

--- a/README.md
+++ b/README.md
@@ -31,36 +31,34 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
 
 * Optional camera videoConfig vcodec, if your running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option.
 
-{
-  "platform": "Camera-ffmpeg",
-  "cameras": [
     {
-      "name": "Camera Name",
-      "videoConfig": {
-        "source": "-re -i rtsp://myfancy_rtsp_stream",
-        "stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg",
-        "maxStreams": 2,
-        "maxWidth": 1280,
-        "maxHeight": 720,
-        "maxFPS": 30,
-        "vcodec": "h264_omx"
-      }
+      "platform": "Camera-ffmpeg",
+      "cameras": [
+        {
+          "name": "Camera Name",
+          "videoConfig": {
+            "source": "-re -i rtsp://myfancy_rtsp_stream",
+            "stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg",
+            "maxStreams": 2,
+            "maxWidth": 1280,
+            "maxHeight": 720,
+            "maxFPS": 30,
+            "vcodec": "h264_omx"
+          }
+        }
+      ]
     }
-  ]
-}
 
 
 ## Google Drive configuration for storage of snapshots
 
-1. For the setup of Google Drive, please for the Google Drive Quickstart for Node.js instructions from here except for these changes.
+* For the setup of Google Drive, please for the Google Drive Quickstart for Node.js instructions from here except for these changes.
 
 https://developers.google.com/drive/v3/web/quickstart/nodejs
 
-* Step 1-h the working directory should be .homebridge directory
+* In Step 1-h the working directory should be .homebridge directory
 * Skip Step 2 and 3
-* And in step 4, use the quickstart.js included in the plugin itself.  And to do this you need to run the command from the plugin directory.  Then just follows steps a to c
-
-
+* And in step 4, use the quickstart.js included in the plugin itself.  And to do this you need to run the command from the plugin directory.  Then just follow steps a to c
 
 ## Tested configurations
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
         {
           "name": "Camera Name",
           "videoConfig": {
-            "source": "-re -i rtsp://myfancy_rtsp_stream",
+          	"source": "-re -i rtsp://myfancy_rtsp_stream",
             "stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg",
-            "maxStreams": 2,
-            "maxWidth": 1280,
-            "maxHeight": 720,
-            "maxFPS": 30,
-            "vcodec": "h264_omx"
+          	"maxStreams": 2,
+          	"maxWidth": 1280,
+          	"maxHeight": 720,
+          	"maxFPS": 30,
+          	"vcodec": "h264_omx"            
           }
         }
       ]

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
 
 ## Uploading to Google Drive of Still Images ( Snapshots )
 
-This feature will automatically load every snapshot taken to Google Drive, so you look at these later.  This is very useful if you have motion sensor in the same room as the camera, as it will take a snapshot of whatever caused the motion sensor to trigger, and store the image on Google Drive and create a Picture Notification on your iOS device.
+This is an optional feature that will automatically store every snapshot taken to your Google Drive account as a photo.  This is very useful if you have motion sensor in the same room as the camera, as it will take a snapshot of whatever caused the motion sensor to trigger, and store the image on Google Drive and create a Picture Notification on your iOS device.
+
+The snaphots are stored in a folder called "Camera Pictures", and are named with camera name, date and time of the image.
 
 To enable this feature, please add a new config option "uploader", and follow the steps below.
 
@@ -79,6 +81,8 @@ To enable this feature, please add a new config option "uploader", and follow th
   ]
 }
 ```
+
+If the option is missing, it defaults to false, and does not enable the uploader.
 
 * For the setup of Google Drive, please follow the Google Drive Quickstart for Node.js instructions from here except for these changes.
 

--- a/drive.js
+++ b/drive.js
@@ -1,0 +1,313 @@
+var debug = require('debug')('CameraDrive');
+var fs = require('fs');
+var readline = require('readline');
+var google = require('googleapis');
+var googleAuth = require('google-auth-library');
+var url = require('url');
+
+module.exports = {
+    drive: drive
+}
+
+// If modifying these scopes, delete your previously saved credentials
+// at ~/.credentials/drive-nodejs-quickstart.json
+var SCOPES = ['https://www.googleapis.com/auth/drive'];
+var TOKEN_DIR = (process.env.HOME || process.env.HOMEPATH ||
+    process.env.USERPROFILE) + '/.homebridge/';
+var TOKEN_PATH = TOKEN_DIR + 'drive-nodejs-quickstart.json';
+var SECRET_PATH = TOKEN_DIR + 'client_secret.json';
+var auth;
+
+function drive() {
+
+    // Load client secrets from a local file.
+    fs.readFile(SECRET_PATH, function processClientSecrets(err, content) {
+        if (err) {
+            console.log('Error loading client secret file: ' + err);
+            return;
+        }
+        // Authorize a client with the loaded credentials, then call the
+        // Drive API.
+        authorize(JSON.parse(content), function(authenticated) {
+
+            auth = authenticated;
+            debug("Authenticated");
+
+        });
+    });
+
+
+}
+
+drive.prototype.storePicture = function(prefix,picture) {
+    // get folder ID
+    debug("getFolder");
+    getPictureFolder(function(err, folder) {
+        debug("upload");
+        uploadPicture(folder, prefix, picture);
+    })
+}
+
+function getPictureFolder(cb) {
+    var folder;
+    var drive = google.drive('v3');
+
+    drive.files.list({
+        q: "mimeType='application/vnd.google-apps.folder' and name = 'Camera Pictures'",
+        fields: 'nextPageToken, files(id, name)',
+        spaces: 'drive',
+        auth: auth
+    }, function(err, res) {
+        if (err) {
+            callback(err);
+        } else {
+            if (res.files.length > 0) {
+                res.files.forEach(function(file) {
+                    debug('Found Folder: ', file.name, file.id);
+                    cb(null, file.id);
+                });
+            } else {
+                var fileMetadata = {
+                    'name': 'Camera Pictures',
+                    'mimeType': 'application/vnd.google-apps.folder'
+                };
+                drive.files.create({
+                    resource: fileMetadata,
+                    fields: 'id',
+                    auth: auth
+                }, function(err, file) {
+                    if (err) {
+                        // Handle error
+                        console.log(err);
+                    } else {
+                        debug("Created Folder", file.id);
+                        cb(null, file.id);
+                    }
+                })
+            }
+        }
+    })
+}
+
+function uploadPicture(folder, prefix, picture) {
+    var drive = google.drive('v3');
+    var d = new Date();
+    var parsedUrl = url.parse(prefix.substr(prefix.search('http')), true, true);
+    var name = prefix.replace(/ /g,"_")+"_"+d.toLocaleString().replace(/ /g,"_")+".jpeg";
+
+    debug("upload picture", folder, name);
+
+    var fileMetadata = {
+        'name': name,
+        parents: [folder]
+    };
+    var media = {
+        mimeType: 'image/jpeg',
+        body: picture
+    };
+
+    drive.files.create({
+        resource: fileMetadata,
+        media: media,
+        fields: 'id',
+        auth: auth
+    }, function(err, file) {
+        if (err) {
+            // Handle error
+            console.log(err);
+        } else {
+            debug('File Id: ', file.id);
+        }
+    });
+
+}
+
+// This is all from the Google Drive Quickstart
+
+/**
+ * Create an OAuth2 client with the given credentials, and then execute the
+ * given callback function.
+ *
+ * @param {Object} credentials The authorization client credentials.
+ * @param {function} callback The callback to call with the authorized client.
+ */
+function authorize(credentials, callback) {
+    var clientSecret = credentials.installed.client_secret;
+    var clientId = credentials.installed.client_id;
+    var redirectUrl = credentials.installed.redirect_uris[0];
+    var auth = new googleAuth();
+    var oauth2Client = new auth.OAuth2(clientId, clientSecret, redirectUrl);
+
+    // Check if we have previously stored a token.
+    fs.readFile(TOKEN_PATH, function(err, token) {
+        if (err) {
+            getNewToken(oauth2Client, callback);
+        } else {
+            oauth2Client.credentials = JSON.parse(token);
+            callback(oauth2Client);
+        }
+    });
+}
+
+/**
+ * Get and store new token after prompting for user authorization, and then
+ * execute the given callback with the authorized OAuth2 client.
+ *
+ * @param {google.auth.OAuth2} oauth2Client The OAuth2 client to get token for.
+ * @param {getEventsCallback} callback The callback to call with the authorized
+ *     client.
+ */
+function getNewToken(oauth2Client, callback) {
+    var authUrl = oauth2Client.generateAuthUrl({
+        access_type: 'offline',
+        scope: SCOPES
+    });
+    console.log('Authorize this app by visiting this url: ', authUrl);
+    var rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout
+    });
+    rl.question('Enter the code from that page here: ', function(code) {
+        rl.close();
+        oauth2Client.getToken(code, function(err, token) {
+            if (err) {
+                console.log('Error while trying to retrieve access token', err);
+                return;
+            }
+            oauth2Client.credentials = token;
+            storeToken(token);
+            callback(oauth2Client);
+        });
+    });
+}
+
+/**
+ * Store token to disk be used in later program executions.
+ *
+ * @param {Object} token The token to store to disk.
+ */
+function storeToken(token) {
+    try {
+        fs.mkdirSync(TOKEN_DIR);
+    } catch (err) {
+        if (err.code != 'EEXIST') {
+            throw err;
+        }
+    }
+    fs.writeFile(TOKEN_PATH, JSON.stringify(token));
+    console.log('Token stored to ' + TOKEN_PATH);
+}
+
+/**
+ * Lists the names and IDs of up to 10 files.
+ *
+ * @param {google.auth.OAuth2} auth An authorized OAuth2 client.
+ */
+function listFiles(auth) {
+    var drive = google.drive('v3');
+    drive.files.list({
+        auth: auth,
+        pageSize: 30,
+        fields: "nextPageToken, files(id, name)"
+    }, function(err, response) {
+        if (err) {
+            console.log('The API returned an error: ' + err);
+            return;
+        }
+        var files = response.files;
+        if (files.length == 0) {
+            debug('No files found.');
+        } else {
+            debug('Files:');
+            for (var i = 0; i < files.length; i++) {
+                var file = files[i];
+                debug('%s (%s)', JSON.stringify(file, null, 2), file.name, file.id);
+            }
+        }
+    });
+}
+
+function uploadFile(auth) {
+    var drive = google.drive('v3');
+
+    var fetchPage = function(pageToken, pageFn, callback) {
+        drive.files.list({
+            q: "mimeType='application/vnd.google-apps.folder' and name = 'Camera Pictures'",
+            fields: 'nextPageToken, files(id, name)',
+            spaces: 'drive',
+            pageToken: pageToken,
+            auth: auth
+        }, function(err, res) {
+            if (err) {
+                callback(err);
+            } else {
+                res.files.forEach(function(file) {
+                    debug('Found file: ', file.name, file.id);
+                });
+                if (res.nextPageToken) {
+                    debug("Page token", res.nextPageToken);
+                    pageFn(res.nextPageToken, pageFn, callback);
+                } else {
+                    callback();
+                }
+            }
+        });
+    };
+    fetchPage(null, fetchPage, function(err) {
+        if (err) {
+            // Handle error
+            console.log(err);
+        } else {
+            // All pages fetched
+        }
+    });
+
+
+
+
+
+    var fileMetadata = {
+        'name': 'Camera Pictures',
+        'mimeType': 'application/vnd.google-apps.folder'
+    };
+    drive.files.create({
+        resource: fileMetadata,
+        fields: 'id',
+        auth: auth
+    }, function(err, file) {
+        if (err) {
+            // Handle error
+            console.log(err);
+        } else {
+            debug('Folder Id: ', file.id);
+
+            var fileMetadata = {
+                'name': 'photo.jpg',
+                parents: [file.id]
+            };
+            var media = {
+                mimeType: 'image/jpeg',
+                body: fs.createReadStream('photo.jpg')
+            };
+
+            drive.files.create({
+                resource: fileMetadata,
+                media: media,
+                fields: 'id',
+                auth: auth
+            }, function(err, file) {
+                if (err) {
+                    // Handle error
+                    console.log(err);
+                } else {
+                    debug('File Id: ', file.id);
+                }
+            });
+
+
+
+        }
+    });
+
+
+}

--- a/drive.js
+++ b/drive.js
@@ -23,7 +23,7 @@ function drive() {
     // Load client secrets from a local file.
     fs.readFile(SECRET_PATH, function processClientSecrets(err, content) {
         if (err) {
-            console.log('Error loading client secret file: ' + err);
+            console.log('Error loading client secret file, please follow the instructions in the README!!!' + err);
             return;
         }
         // Authorize a client with the loaded credentials, then call the
@@ -59,7 +59,7 @@ function getPictureFolder(cb) {
         auth: auth
     }, function(err, res) {
         if (err) {
-            callback(err);
+            cb(err);
         } else {
             if (res.files.length > 0) {
                 res.files.forEach(function(file) {

--- a/drive.js
+++ b/drive.js
@@ -39,13 +39,15 @@ function drive() {
 
 }
 
-drive.prototype.storePicture = function(prefix,picture) {
+drive.prototype.storePicture = function(prefix, picture) {
     // get folder ID
     debug("getFolder");
-    getPictureFolder(function(err, folder) {
-        debug("upload");
-        uploadPicture(folder, prefix, picture);
-    })
+    if (auth) {
+        getPictureFolder(function(err, folder) {
+            debug("upload");
+            uploadPicture(folder, prefix, picture);
+        })
+    }
 }
 
 function getPictureFolder(cb) {
@@ -93,7 +95,7 @@ function uploadPicture(folder, prefix, picture) {
     var drive = google.drive('v3');
     var d = new Date();
     var parsedUrl = url.parse(prefix.substr(prefix.search('http')), true, true);
-    var name = prefix.replace(/ /g,"_")+"_"+d.toLocaleString().replace(/ /g,"_")+".jpeg";
+    var name = prefix.replace(/ /g, "_") + "_" + d.toLocaleString().replace(/ /g, "_") + ".jpeg";
 
     debug("upload picture", folder, name);
 

--- a/drive.js
+++ b/drive.js
@@ -95,7 +95,7 @@ function uploadPicture(folder, prefix, picture) {
     var drive = google.drive('v3');
     var d = new Date();
     var parsedUrl = url.parse(prefix.substr(prefix.search('http')), true, true);
-    var name = prefix.replace(/ /g, "_") + "_" + d.toLocaleString().replace(/ /g, "_") + ".jpeg";
+    var name = prefix.replace(/ /g, "_") + "_" + d.toLocaleString().replace(/ /g, "_").replace(/,/g, "") + ".jpeg";
 
     debug("upload picture", folder, name);
 

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -224,7 +224,6 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
         var height = 720;
         var fps = 30;
         var bitrate = 300;
-        console.log(this);
         var vcodec = this.vcodec || 'libx264';
 
         let videoInfo = request["video"];

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -132,8 +132,6 @@ FFMPEG.prototype.handleCloseConnection = function(connectionID) {
 
 FFMPEG.prototype.handleSnapshotRequest = function(request, callback) {
   let resolution = request.width + 'x' + request.height;
-  if ( this.uploader )
-    { resolution = this.maxWidth + 'x' + this.maxHeight; }
   var imageSource = this.ffmpegImageSource !== undefined ? this.ffmpegImageSource : this.ffmpegSource;
   let ffmpeg = spawn('ffmpeg', (imageSource + ' -t 1 -s '+ resolution + ' -f image2 -').split(' '), {env: process.env});
   var imageBuffer = Buffer(0);

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ ffmpegPlatform.prototype.didFinishLaunching = function() {
 
       var uuid = UUIDGen.generate(cameraName);
       var cameraAccessory = new Accessory(cameraName, uuid, hap.Accessory.Categories.CAMERA);
-      var cameraSource = new FFMPEG(hap, videoConfig);
+      var cameraSource = new FFMPEG(hap, cameraConfig);
       cameraAccessory.configureCameraSource(cameraSource);
       configuredAccessories.push(cameraAccessory);
     });

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "homebridge": ">=0.4.5"
   },
   "dependencies": {
-    "ip": "^1.1.3"
+    "google-auth-library": "^0.10.0",
+    "googleapis": "^18.0.0",
+    "ip": "^1.1.3",
+    "debug": "^2.2.0"
   }
 }

--- a/quickstart.js
+++ b/quickstart.js
@@ -1,0 +1,3 @@
+var drive = require('./drive').drive;
+
+this.uploader = new drive();


### PR DESCRIPTION
I'm using this in combination with a motion sensor to watch my front porch, and see who is coming and going, but what I felt was lacking was storage of the pictures.  They would appear on my phone, allowing a quick view but would go away afterwards not allowing you to store a picture for later.

This pull request adds the functionality without forcing usage, and if it isn't configured the plugin continues to work normally.

I also added as a config parameter vcodec, so that you could use alternate video codecs like the RaspberryPI optimized h264_omx without resorting to editing ffmpeg.js.