### PR TITLE
Better TERM than KILL

### DIFF
--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -259,7 +259,7 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
     } else if (requestType == "stop") {
       var ffmpegProcess = this.ongoingSessions[sessionIdentifier];
       if (ffmpegProcess) {
-        ffmpegProcess.kill('SIGKILL');
+        ffmpegProcess.kill('SIGTERM');
       }
 
       delete this.ongoingSessions[sessionIdentifier];


### PR DESCRIPTION
for those who are using a ffmpeg bash file to wrap around avconv, that allow to handle the signal and kill the child process

on a Jessie Raspbian, there is no ffmpeg in sources, but avconv exists and the plugin could works with a wrapper
example : 
file /usr/bin/ffmpeg (the wrapper) :
```
#!/bin/bash 

_term() { 
  echo "SIGTERM received!" 
  kill -SIGTERM "$child" 2>/dev/null
}

trap _term SIGTERM

sudo /usr/bin/avconv $@

child=$! 
wait "$child"
```

fyi SIGKILL cannot be trapped