### PR TITLE
Allow ffmpeg or avconv + SIGTERM instead of SIGKILL

### DIFF
--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -10,7 +10,7 @@ module.exports = {
   FFMPEG: FFMPEG
 };
 
-function FFMPEG(hap, cameraConfig) {
+function FFMPEG(hap, cameraConfig, videoProcessor) {
   uuid = hap.uuid;
   Service = hap.Service;
   Characteristic = hap.Characteristic;
@@ -19,6 +19,7 @@ function FFMPEG(hap, cameraConfig) {
   var ffmpegOpt = cameraConfig.videoConfig;
   this.name = cameraConfig.name;
   this.vcodec = ffmpegOpt.vcodec;
+  this.videoProcessor = videoProcessor || 'ffmpeg';
 
   if (!ffmpegOpt.source) {
     throw new Error("Missing source for camera.");
@@ -133,7 +134,7 @@ FFMPEG.prototype.handleCloseConnection = function(connectionID) {
 FFMPEG.prototype.handleSnapshotRequest = function(request, callback) {
   let resolution = request.width + 'x' + request.height;
   var imageSource = this.ffmpegImageSource !== undefined ? this.ffmpegImageSource : this.ffmpegSource;
-  let ffmpeg = spawn('ffmpeg', (imageSource + ' -t 1 -s '+ resolution + ' -f image2 -').split(' '), {env: process.env});
+  let ffmpeg = spawn(this.videoProcessor, (imageSource + ' -t 1 -s '+ resolution + ' -f image2 -').split(' '), {env: process.env});
   var imageBuffer = Buffer(0);
   console.log("Snapshot",imageSource + ' -t 1 -s '+ resolution + ' -f image2 -');
   ffmpeg.stdout.on('data', function(data) {
@@ -251,7 +252,7 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
          videoKey.toString('base64')+' srtp://'+targetAddress+':'+targetVideoPort+'?rtcpport='+targetVideoPort+
          '&localrtcpport='+targetVideoPort+'&pkt_size=1378';
         console.log(ffmpegCommand);
-        let ffmpeg = spawn('ffmpeg', ffmpegCommand.split(' '), {env: process.env});
+        let ffmpeg = spawn(this.videoProcessor, ffmpegCommand.split(' '), {env: process.env});
         this.ongoingSessions[sessionIdentifier] = ffmpeg;
       }
 

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -259,7 +259,7 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
     } else if (requestType == "stop") {
       var ffmpegProcess = this.ongoingSessions[sessionIdentifier];
       if (ffmpegProcess) {
-        ffmpegProcess.kill('SIGKILL');
+        ffmpegProcess.kill('SIGTERM');
       }
 
       delete this.ongoingSessions[sessionIdentifier];

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ ffmpegPlatform.prototype.configureAccessory = function(accessory) {
 
 ffmpegPlatform.prototype.didFinishLaunching = function() {
   var self = this;
+  var videoProcessor = self.config.videoProcessor || 'ffmpeg';
 
   if (self.config.cameras) {
     var configuredAccessories = [];
@@ -46,8 +47,7 @@ ffmpegPlatform.prototype.didFinishLaunching = function() {
         self.log("Missing parameters.");
         return;
       }
-
-      var videoProcessor = self.config.videoProcessor || 'ffmpeg';
+      
       var uuid = UUIDGen.generate(cameraName);
       var cameraAccessory = new Accessory(cameraName, uuid, hap.Accessory.Categories.CAMERA);
       var cameraSource = new FFMPEG(hap, cameraConfig, videoProcessor);

--- a/index.js
+++ b/index.js
@@ -47,9 +47,10 @@ ffmpegPlatform.prototype.didFinishLaunching = function() {
         return;
       }
 
+      var videoProcessor = self.config.videoProcessor || 'ffmpeg';
       var uuid = UUIDGen.generate(cameraName);
       var cameraAccessory = new Accessory(cameraName, uuid, hap.Accessory.Categories.CAMERA);
-      var cameraSource = new FFMPEG(hap, cameraConfig);
+      var cameraSource = new FFMPEG(hap, cameraConfig, videoProcessor);
       cameraAccessory.configureCameraSource(cameraSource);
       configuredAccessories.push(cameraAccessory);
     });


### PR DESCRIPTION
for those who are using a ffmpeg bash file to wrap around avconv, that allow to handle the signal and kill the child process

on a Jessie Raspbian, there is no ffmpeg in sources, but avconv exists and the plugin could works with a wrapper
example : 
file /usr/bin/ffmpeg (the wrapper) :
```
#!/bin/bash 

_term() { 
  echo "SIGTERM received!" 
  kill -SIGTERM "$child" 2>/dev/null
}

trap _term SIGTERM

sudo /usr/bin/avconv $@

child=$! 
wait "$child"
```

fyi SIGKILL cannot be trapped

or

we may use avconv directly in the config file with videoProcessor attribute