### PR TITLE
Add audio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
       ]
     }
 
-* Optional parameter vcodec, if your running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option.
+#### Optional Parameters
+
+* `vcodec`, if your running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option.
+* `audio`, can be set to true to enable audio streaming from camera. To use audio ffmpeg must be compiled with --enable-libfdk-aac, see http://praveen.life/2016/06/26/compile-ffmpeg-for-raspberry-pi-3/
+* `packetSize`, can be set to a multiple of 188, default 1316. If audio or video is choppy try a smaller value.
 
 ```
 {
@@ -44,7 +48,9 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
       	"maxWidth": 1280,
       	"maxHeight": 720,
       	"maxFPS": 30,
-      	"vcodec": "h264_omx"            
+      	"vcodec": "h264_omx",
+        "audio": true,
+        "packetSize": 188
       }
     }
   ]
@@ -55,7 +61,7 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
 
 This is an optional feature that will automatically store every snapshot taken to your Google Drive account as a photo.  This is very useful if you have motion sensor in the same room as the camera, as it will take a snapshot of whatever caused the motion sensor to trigger, and store the image on Google Drive and create a Picture Notification on your iOS device.
 
-The snaphots are stored in a folder called "Camera Pictures", and are named with camera name, date and time of the image.
+The snapshots are stored in a folder called "Camera Pictures", and are named with camera name, date and time of the image.
 
 To enable this feature, please add a new config option "uploader", and follow the steps below.
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
       	"maxHeight": 720,
       	"maxFPS": 30,
       	"vcodec": "h264_omx",
-        "audio": true,
-        "packetSize": 188
+      	"audio": true,
+      	"packetSize": 188
       }
     }
   ]

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -22,6 +22,7 @@ function FFMPEG(hap, cameraConfig) {
   this.vcodec = ffmpegOpt.vcodec;
   this.audio = ffmpegOpt.audio;
   this.packetsize = ffmpegOpt.packetSize
+  this.fps = ffmpegOpt.maxFPS;
 
   if (!ffmpegOpt.source) {
     throw new Error("Missing source for camera.");
@@ -237,7 +238,7 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
       if (sessionInfo) {
         var width = 1280;
         var height = 720;
-        var fps = 30;
+        var fps = this.fps || 30;
         var vbitrate = 300;
         var abitrate = 32;
         var asamplerate = 16;

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -273,6 +273,7 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
 
         let ffmpegCommand = this.ffmpegSource + ' -map 0:0' +
           ' -vcodec ' + vcodec +
+          ' -pix_fmt yuv420p' +
           ' -r ' + fps +
           ' -vf scale=' + width + ':' + height +
           ' -b:v ' + vbitrate + 'k' +

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -21,6 +21,7 @@ function FFMPEG(hap, cameraConfig) {
   this.name = cameraConfig.name;
   this.vcodec = ffmpegOpt.vcodec;
   this.audio = ffmpegOpt.audio;
+  this.acodec = ffmpegOpt.acodec;
   this.packetsize = ffmpegOpt.packetSize
   this.fps = ffmpegOpt.maxFPS;
 
@@ -243,6 +244,7 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
         var abitrate = 32;
         var asamplerate = 16;
         var vcodec = this.vcodec || 'libx264';
+        var acodec = this.acodec || 'libfdk_aac';
         var packetsize = this.packetsize || 1316; // 188 376
 
         let videoInfo = request["video"];
@@ -291,7 +293,7 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
 
         if(this.audio){
           ffmpegCommand+= ' -map 0:1' +
-            ' -acodec libfdk_aac' +
+            ' -acodec ' + acodec +
             ' -profile:a aac_eld' +
             ' -flags +global_header' +
             ' -f null' +

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -20,6 +20,8 @@ function FFMPEG(hap, cameraConfig) {
   var ffmpegOpt = cameraConfig.videoConfig;
   this.name = cameraConfig.name;
   this.vcodec = ffmpegOpt.vcodec;
+  this.audio = ffmpegOpt.audio;
+  this.packetsize = ffmpegOpt.packetSize
 
   if (!ffmpegOpt.source) {
     throw new Error("Missing source for camera.");
@@ -236,8 +238,11 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
         var width = 1280;
         var height = 720;
         var fps = 30;
-        var bitrate = 300;
+        var vbitrate = 300;
+        var abitrate = 32;
+        var asamplerate = 16;
         var vcodec = this.vcodec || 'libx264';
+        var packetsize = this.packetsize || 1316; // 188 376
 
         let videoInfo = request["video"];
         if (videoInfo) {
@@ -249,22 +254,63 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
             fps = expectedFPS;
           }
 
-          bitrate = videoInfo["max_bit_rate"];
+          vbitrate = videoInfo["max_bit_rate"];
+        }
+
+        let audioInfo = request["audio"];
+        if (audioInfo) {
+          abitrate = audioInfo["max_bit_rate"];
+          asamplerate = audioInfo["sample_rate"];
         }
 
         let targetAddress = sessionInfo["address"];
         let targetVideoPort = sessionInfo["video_port"];
         let videoKey = sessionInfo["video_srtp"];
         let videoSsrc = sessionInfo["video_ssrc"];
+        let targetAudioPort = sessionInfo["audio_port"];
+        let audioKey = sessionInfo["audio_srtp"];
+        let audioSsrc = sessionInfo["audio_ssrc"];
 
-        let ffmpegCommand = this.ffmpegSource + ' -threads 0 -vcodec '+vcodec+' -an -pix_fmt yuv420p -r '+
-        fps +' -f rawvideo -tune zerolatency -vf scale='+ width +':'+ height +' -b:v '+ bitrate +'k -bufsize '+
-         bitrate +'k -payload_type 99 -ssrc '+ videoSsrc +' -f rtp -srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params '+
-         videoKey.toString('base64')+' srtp://'+targetAddress+':'+targetVideoPort+'?rtcpport='+targetVideoPort+
-         '&localrtcpport='+targetVideoPort+'&pkt_size=1378';
-        console.log(ffmpegCommand);
+        let ffmpegCommand = this.ffmpegSource + ' -map 0:0' +
+          ' -vcodec ' + vcodec +
+          ' -r ' + fps +
+          ' -vf scale=' + width + ':' + height +
+          ' -b:v ' + vbitrate + 'k' +
+          ' -bufsize ' + vbitrate + 'k' +
+          ' -payload_type 99' +
+          ' -ssrc ' + videoSsrc +
+          ' -f rtp' +
+          ' -srtp_out_suite AES_CM_128_HMAC_SHA1_80' +
+          ' -srtp_out_params ' + videoKey.toString('base64') +
+          ' srtp://' + targetAddress + ':' + targetVideoPort +
+          '?rtcpport=' + targetVideoPort +
+          '&localrtcpport=' + targetVideoPort +
+          '&pkt_size=' + packetsize;
+
+        if(this.audio){
+          ffmpegCommand+= ' -map 0:1' +
+            ' -acodec libfdk_aac' +
+            ' -profile:a aac_eld' +
+            ' -flags +global_header' +
+            ' -f null' +
+            ' -ar ' + asamplerate + 'k' +
+            ' -b:a ' + abitrate + 'k' +
+            ' -bufsize ' + abitrate + 'k' +
+            ' -ac 1' +
+            ' -payload_type 110' +
+            ' -ssrc ' + audioSsrc +
+            ' -f rtp' +
+            ' -srtp_out_suite AES_CM_128_HMAC_SHA1_80' +
+            ' -srtp_out_params ' + audioKey.toString('base64') +
+            ' srtp://' + targetAddress + ':' + targetAudioPort +
+            '?rtcpport=' + targetAudioPort +
+            '&localrtcpport=' + targetAudioPort +
+            '&pkt_size=' + packetsize;
+        }
+
         let ffmpeg = spawn('ffmpeg', ffmpegCommand.split(' '), {env: process.env});
         this.ongoingSessions[sessionIdentifier] = ffmpeg;
+        console.log("ffmpeg " + ffmpegCommand);
       }
 
       delete this.pendingSessions[sessionIdentifier];
@@ -272,6 +318,7 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
       var ffmpegProcess = this.ongoingSessions[sessionIdentifier];
       if (ffmpegProcess) {
         ffmpegProcess.kill('SIGKILL');
+        console.log("Stopped ffmpeg");
       }
 
       delete this.ongoingSessions[sessionIdentifier];

--- a/index.js
+++ b/index.js
@@ -51,6 +51,10 @@ ffmpegPlatform.prototype.didFinishLaunching = function() {
       var cameraAccessory = new Accessory(cameraName, uuid, hap.Accessory.Categories.CAMERA);
       var cameraSource = new FFMPEG(hap, cameraConfig);
       cameraAccessory.configureCameraSource(cameraSource);
+      if(videoConfig.audio){
+        var microphoneService = new Service.Microphone("Microphone");
+        cameraAccessory.addService(microphoneService);
+      }
       configuredAccessories.push(cameraAccessory);
     });
 


### PR DESCRIPTION
- add support for audio streams
- add support for changing packet size via config file
- apply MaxFPS to video output
- small cleanups

I combined the various info on audio and added (optional) support for audio to the plugin.

The MaxFPS was only used to supply video formats but as HomeKit seems to ask for a higher framerate anyway I use it to cap the video output now.

I also organized the ffmpeg command creation a bit so that it's easier to make (and see) changes. I removed the "-tune" parameter as it doesn't seem to work in the latest version of ffmpeg.

I thought a PR was in order, just close it if theres no interest, if changes are required tell me.