### PR TITLE
Add default values for most parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
           "videoConfig": {
           	"source": "-re -i rtsp://myfancy_rtsp_stream",
           	"stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg"
+          	"maxStreams": 2,
+          	"maxWidth": 1280,
+          	"maxHeight": 720,
+          	"maxFPS": 30,
           }
         }
       ]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
 * `vcodec` If you're running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option, default "libx264"
 * `audio` can be set to true to enable audio streaming from camera. To use audio ffmpeg must be compiled with --enable-libfdk-aac, see https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki, default false
 * `packetSize` If audio or video is choppy try a smaller value, set to a multiple of 188, default 1316
+* `debug` Show the output of ffmpeg in the log, default false
 
 ```
 {
@@ -50,7 +51,8 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
       	"maxFPS": 30,
       	"vcodec": "h264_omx",
       	"audio": true,
-      	"packetSize": 188
+      	"packetSize": 188,
+      	"debug": true
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
           	"maxStreams": 2,
           	"maxWidth": 1280,
           	"maxHeight": 720,
-          	"maxFPS": 30,
+          	"maxFPS": 30
           }
         }
       ]

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
 #### Optional Parameters
 
 * `maxStreams` is the maximum number of streams that will be generated for this camera, default 2
-* `maxWidth` is the maximum width of the generated stream to avoid unnecessary upscaling, default 1280
-* `maxHeight` is the maximum height of the generated stream to avoid unnecessary upscaling, default 720
+* `maxWidth` is the maximum width reported to HomeKit, default 1280
+* `maxHeight` is the maximum height reported to HomeKit, default 720
 * `maxFPS` is the maximum frame rate of the stream, default 10
+* `maxBitrate` is the maximum frame rate of the stream in kbit/s, default 300
 * `vcodec` If you're running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option, default "libx264"
 * `audio` can be set to true to enable audio streaming from camera. To use audio ffmpeg must be compiled with --enable-libfdk-aac, see https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki, default false
 * `packetSize` If audio or video is choppy try a smaller value, set to a multiple of 188, default 1316

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
 
 ## Installation
 
-1. Install ffmpeg on your Mac
+1. Install ffmpeg on your computer
 2. Install this plugin using: npm install -g homebridge-camera-ffmpeg
 3. Edit ``config.json`` and add the camera.
 3. Run Homebridge
@@ -19,11 +19,7 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
           "name": "Camera Name",
           "videoConfig": {
           	"source": "-re -i rtsp://myfancy_rtsp_stream",
-            "stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg",
-          	"maxStreams": 2,
-          	"maxWidth": 1280,
-          	"maxHeight": 720,
-          	"maxFPS": 30
+          	"stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg"
           }
         }
       ]
@@ -31,9 +27,13 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
 
 #### Optional Parameters
 
-* `vcodec`, if your running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option.
-* `audio`, can be set to true to enable audio streaming from camera. To use audio ffmpeg must be compiled with --enable-libfdk-aac, see http://praveen.life/2016/06/26/compile-ffmpeg-for-raspberry-pi-3/
-* `packetSize`, can be set to a multiple of 188, default 1316. If audio or video is choppy try a smaller value.
+* `maxStreams` is the maximum number of streams that will be generated for this camera, default 2
+* `maxWidth` is the maximum width of the generated stream to avoid unnecessary upscaling, default 1280
+* `maxHeight` is the maximum height of the generated stream to avoid unnecessary upscaling, default 720
+* `maxFPS` is the maximum frame rate of the stream, default 10
+* `vcodec` If you're running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option, default "libx264"
+* `audio` can be set to true to enable audio streaming from camera. To use audio ffmpeg must be compiled with --enable-libfdk-aac, see https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki, default false
+* `packetSize` If audio or video is choppy try a smaller value, set to a multiple of 188, default 1316
 
 ```
 {

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -25,6 +25,7 @@ function FFMPEG(hap, cameraConfig, log) {
   this.acodec = ffmpegOpt.acodec;
   this.packetsize = ffmpegOpt.packetSize
   this.fps = ffmpegOpt.maxFPS || 10;
+  this.maxBitrate = ffmpegOpt.maxBitrate || 300;
   this.debug = ffmpegOpt.debug;
 
   if (!ffmpegOpt.source) {
@@ -243,7 +244,7 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
         var width = 1280;
         var height = 720;
         var fps = this.fps || 30;
-        var vbitrate = 300;
+        var vbitrate = this.maxBitrate;
         var abitrate = 32;
         var asamplerate = 16;
         var vcodec = this.vcodec || 'libx264';
@@ -259,8 +260,9 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
           if (expectedFPS < fps) {
             fps = expectedFPS;
           }
-
-          vbitrate = videoInfo["max_bit_rate"];
+          if(videoInfo["max_bit_rate"] < vbitrate) {
+            vbitrate = videoInfo["max_bit_rate"];
+          }
         }
 
         let audioInfo = request["audio"];

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -45,9 +45,9 @@ function FFMPEG(hap, cameraConfig) {
   var numberOfStreams = ffmpegOpt.maxStreams || 2;
   var videoResolutions = [];
 
-  this.maxWidth = ffmpegOpt.maxWidth;
-  this.maxHeight = ffmpegOpt.maxHeight;
-  var maxFPS = (ffmpegOpt.maxFPS > 30) ? 30 : ffmpegOpt.maxFPS;
+  this.maxWidth = ffmpegOpt.maxWidth || 1280;
+  this.maxHeight = ffmpegOpt.maxHeight || 720;
+  var maxFPS = (ffmpegOpt.maxFPS > 30) ? 30 : ffmpegOpt.maxFPS || 10;
 
   if (this.maxWidth >= 320) {
     if (this.maxHeight >= 240) {

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -23,7 +23,7 @@ function FFMPEG(hap, cameraConfig) {
   this.audio = ffmpegOpt.audio;
   this.acodec = ffmpegOpt.acodec;
   this.packetsize = ffmpegOpt.packetSize
-  this.fps = ffmpegOpt.maxFPS;
+  this.fps = ffmpegOpt.maxFPS || 10;
 
   if (!ffmpegOpt.source) {
     throw new Error("Missing source for camera.");
@@ -47,7 +47,7 @@ function FFMPEG(hap, cameraConfig) {
 
   this.maxWidth = ffmpegOpt.maxWidth || 1280;
   this.maxHeight = ffmpegOpt.maxHeight || 720;
-  var maxFPS = (ffmpegOpt.maxFPS > 30) ? 30 : ffmpegOpt.maxFPS || 10;
+  var maxFPS = (this.fps > 30) ? 30 : this.fps;
 
   if (this.maxWidth >= 320) {
     if (this.maxHeight >= 240) {

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ ffmpegPlatform.prototype.didFinishLaunching = function() {
 
       var uuid = UUIDGen.generate(cameraName);
       var cameraAccessory = new Accessory(cameraName, uuid, hap.Accessory.Categories.CAMERA);
-      var cameraSource = new FFMPEG(hap, cameraConfig);
+      var cameraSource = new FFMPEG(hap, cameraConfig, self.log);
       cameraAccessory.configureCameraSource(cameraSource);
       configuredAccessories.push(cameraAccessory);
     });


### PR DESCRIPTION
This PR creates default values for most parameters so they don't have to be entered in the config file for each camera. Notably it limits the frame rate to 10 fps by default as this seems to greatly improve the latency and video quality on the iOS side for my various cameras. Otherwise the values are basically left as they were. It also updates the README.

I'd be happy if the PR would not be squashed but simply merged so I can continue working in my forked repo without having messy future PRs or having to delete it each time I want to make a PR for this project :)