### PR TITLE
Allow passing additional command line options to ffmpeg.

### DIFF
--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -289,7 +289,8 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
           ' ' + additionalCommandline +
           ' -vf scale=' + width + ':' + height +
           ' -b:v ' + vbitrate + 'k' +
-          ' -bufsize ' + vbitrate + 'k' +
+          ' -bufsize ' + vbitrate+ 'k' +
+          ' -maxrate '+ vbitrate + 'k' +
           ' -payload_type 99' +
           ' -ssrc ' + videoSsrc +
           ' -f rtp' +

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -329,7 +329,7 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
         }
 
         // Always setup hook on stderr. 
-        // Without this streaming stop withing one to two minutes.
+        // Without this streaming stops within one to two minutes.
         ffmpeg.stderr.on('data', function(data) {
           // Do not log to the console if debugging is turned off
           if(this.debug){

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -27,6 +27,7 @@ function FFMPEG(hap, cameraConfig, log) {
   this.fps = ffmpegOpt.maxFPS || 10;
   this.maxBitrate = ffmpegOpt.maxBitrate || 300;
   this.debug = ffmpegOpt.debug;
+  this.additionalCommandline = ffmpegOpt.additionalCommandline || '-tune zerolatency';
 
   if (!ffmpegOpt.source) {
     throw new Error("Missing source for camera.");
@@ -250,6 +251,7 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
         var vcodec = this.vcodec || 'libx264';
         var acodec = this.acodec || 'libfdk_aac';
         var packetsize = this.packetsize || 1316; // 188 376
+        var additionalCommandline = this.additionalCommandline ;
 
         let videoInfo = request["video"];
         if (videoInfo) {
@@ -283,7 +285,8 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
           ' -vcodec ' + vcodec +
           ' -pix_fmt yuv420p' +
           ' -r ' + fps +
-          ' -f rawvideo -tune zerolatency' +
+          ' -f rawvideo' +
+          ' ' + additionalCommandline +
           ' -vf scale=' + width + ':' + height +
           ' -b:v ' + vbitrate + 'k' +
           ' -bufsize ' + vbitrate + 'k' +
@@ -322,10 +325,16 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
         this.log("Start streaming video from " + this.name + " with " + width + "x" + height + "@" + vbitrate + "kBit");
         if(this.debug){
           console.log("ffmpeg " + ffmpegCommand);
-          ffmpeg.stderr.on('data', function(data) {
-            console.log(data.toString());
-          });
         }
+
+        // Always setup hook on stderr. 
+        // Without this streaming stop withing one to two minutes.
+        ffmpeg.stderr.on('data', function(data) {
+          // Do not log to the console if debugging is turned off
+          if(this.debug){
+            console.log(data.toString());
+          }
+        });
         let self = this;
         ffmpeg.on('close', (code) => {
           if(code == null || code == 0 || code == 255){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-camera-ffmpeg",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "ffmpeg plugin for homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-camera-ffmpeg",
-  "version": "0.1.7",
+  "version": "0.1.6",
   "description": "ffmpeg plugin for homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [


### PR DESCRIPTION
- This will allow passing additional command line options via config to ffmpeg. If none are set, it will pass **-tune zerolatency**.

- Also always setup a stderr listener on ffmpeg process to avoid steam from stopping every minute or two.