### PR TITLE
Remove video scaling option if vcodec is set to ‘copy’.

### DIFF
--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -293,7 +293,7 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
           ' -r ' + fps +
           ' -f rawvideo' +
           ' ' + additionalCommandline +
-          ' -vf scale=' + width + ':' + height +
+          ((vcodec !== 'copy') ? (' -vf scale=' + width + ':' + height) : '') +
           ' -b:v ' + vbitrate + 'k' +
           ' -bufsize ' + vbitrate+ 'k' +
           ' -maxrate '+ vbitrate + 'k' +


### PR DESCRIPTION
If the camera already encodes H.264 video that Homekit can understand, 'copy' is a viable choice as ffmpeg's vcodec option to save a lot of CPU time, rather than recompressing the video stream again.

However, if the video stream is supposed to be copied, ffmpeg will choke on the scaling option, so it should be removed from the command line in this case.