### PR TITLE
Allow polling of static images and upload them to shared drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ https://developers.google.com/drive/v3/web/quickstart/nodejs
 * Skip Step 2 and 3
 * And in step 4, use the quickstart.js included in the plugin itself.  And to do this you need to run the command from the plugin directory.  Then just follow steps a to c
 
+* Add the option "pollingInterval", if you're willing to receive static image from camera every `n` seconds (use this, if you don't want to use any motion detection to enable camera)
+
 ## Tested configurations
 
 We have started collecting tested configurations in the wiki, so please before raising an issue with your configuration, please check the [wiki](https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki).  Also if you have a working configuration that you would like to share, please add it to the [wiki](https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki).


### PR DESCRIPTION
I was looking to way, how to automatically push static images from my home cameras to shared drive. I'm not able to use any motion detection device, so I prepared this pull request, that allow poll cameras every n-seconds.

Also, when poll interval is set below 1 minute, all devices, that requests static images, receives cached image to reduce load of remote cameras.