### PR TITLE
Flip It!  🙃

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
 * `maxBitrate` is the maximum bit rate of the stream in kbit/s, default 300
 * `vcodec` If you're running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option, default "libx264"
 * `audio` can be set to true to enable audio streaming from camera. To use audio ffmpeg must be compiled with --enable-libfdk-aac, see https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki, default false
+* `hflip` Flips the stram horizontally, default false
+* `vflip` Flips the stram vertically, default false
 * `packetSize` If audio or video is choppy try a smaller value, set to a multiple of 188, default 1316
 * `debug` Show the output of ffmpeg in the log, default false
 
@@ -57,6 +59,8 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
       	"maxBitrate": 200,
       	"vcodec": "h264_omx",
       	"audio": true,
+      	"vflip": true,
+      	"hflip": true,
       	"packetSize": 188,
       	"debug": true
       }

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -144,11 +144,20 @@ FFMPEG.prototype.handleCloseConnection = function(connectionID) {
 
 FFMPEG.prototype.handleSnapshotRequest = function(request, callback) {
   let resolution = request.width + 'x' + request.height;
+
+  var vf = ['scale=' + request.width + ':' + request.height];
+  if(this.hflip) {
+    vf.push('hflip');
+  }
+  if(this.vflip) {
+    vf.push('vflip');
+  }
+  
   var imageSource = this.ffmpegImageSource !== undefined ? this.ffmpegImageSource : this.ffmpegSource;
-  let ffmpeg = spawn(this.videoProcessor, (imageSource + ' -t 1 -s '+ resolution + ' -f image2 -').split(' '), {env: process.env});
+  let ffmpeg = spawn(this.videoProcessor, (imageSource + ' -t 1 -vf ' + vf.join(',') + ' -f image2 -').split(' '), {env: process.env});
   var imageBuffer = Buffer(0);
   this.log("Snapshot from " + this.name + " at " + resolution);
-  if(this.debug) console.log('ffmpeg '+imageSource + ' -t 1 -s '+ resolution + ' -f image2 -');
+  if(this.debug) console.log('ffmpeg '+imageSource + ' -t 1 -vf ' + vf.join(',') + ' -f image2 -');
   ffmpeg.stdout.on('data', function(data) {
     imageBuffer = Buffer.concat([imageBuffer, data]);
   });
@@ -293,7 +302,6 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
         if(this.hflip) {
           vf.push('hflip');
         }
-
         if(this.vflip) {
           vf.push('vflip');
         }

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -28,6 +28,8 @@ function FFMPEG(hap, cameraConfig, log, videoProcessor) {
   this.fps = ffmpegOpt.maxFPS || 10;
   this.maxBitrate = ffmpegOpt.maxBitrate || 300;
   this.debug = ffmpegOpt.debug;
+  this.hflip = ffmpegOpt.hflip;
+  this.vflip = ffmpegOpt.vflip;
   this.additionalCommandline = ffmpegOpt.additionalCommandline || '-tune zerolatency';
 
   if (!ffmpegOpt.source) {
@@ -286,6 +288,15 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
         let targetAudioPort = sessionInfo["audio_port"];
         let audioKey = sessionInfo["audio_srtp"];
         let audioSsrc = sessionInfo["audio_ssrc"];
+        
+        var vf = ['scale=' + width + ':' + height];
+        if(this.hflip) {
+          vf.push('hflip');
+        }
+
+        if(this.vflip) {
+          vf.push('vflip');
+        }
 
         let ffmpegCommand = this.ffmpegSource + ' -map 0:0' +
           ' -vcodec ' + vcodec +
@@ -293,7 +304,7 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
           ' -r ' + fps +
           ' -f rawvideo' +
           ' ' + additionalCommandline +
-          ' -vf scale=' + width + ':' + height +
+          ' -vf ' + vf.join(',') +
           ' -b:v ' + vbitrate + 'k' +
           ' -bufsize ' + vbitrate+ 'k' +
           ' -maxrate '+ vbitrate + 'k' +


### PR DESCRIPTION
This PR adds the option to flip the video & snapshot horizontally and/or vertically, with corresponding documentation additions - in turn, this all helps address #16.  I admit I don't work with JS a lot these days, so I'm open to any implementation detail improvements.

As a slight aside, given an MPEG2 video source on a RPi (with relevant license enabled) & using the OMX encoder, I actually find the video stream fails far less with a flip filter added for some reason 🤔