### PR TITLE
Removing ffmpeg video scaling when copy codec is used.  This prevents…

### DIFF
--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -293,7 +293,7 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
           ' -r ' + fps +
           ' -f rawvideo' +
           ' ' + additionalCommandline +
-          ' -vf scale=' + width + ':' + height +
+          ((vcodec !== 'copy') ? (' -vf scale=' + width + ':' + height) : '') +
           ' -b:v ' + vbitrate + 'k' +
           ' -bufsize ' + vbitrate+ 'k' +
           ' -maxrate '+ vbitrate + 'k' +


### PR DESCRIPTION
Original discussion on Reddit thread:
https://www.reddit.com/r/homebridge/comments/a8e1bl/wyze_cam_issues/

When using a camera that already supports H264 output we can get better quality by using the copy command.  However when selecting the copy codec in config.json ffmpeg errors out on the live stream with the following issues:

Stream #0:0: Video: h264 (Constrained Baseline), yuv420p(progressive), 1280x720, 25 fps, 24.92 tbr, 90k tbn, 50 tbc
Filtergraph 'scale=1280:720' was defined for video output stream 0:0 but codec copy was selected.

By conditionally removing the scaling option in ffmpeg.js this removes the conflict and the stream works just fine in the Home.app.

Many thanks to u/dalethomas81 for finding the solution.