### PR TITLE
Enable custom arguments to be passed to video processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
 * `packetSize` If audio or video is choppy try a smaller value, set to a multiple of 188, default 1316
 * `debug` Show the output of ffmpeg in the log, default false
 * `additionalCommandline` Allows additional of extra command line options
-* `overrideArgs` Allows overriding all arguments. **Note:** You will need to specify every option, so it is best to ensure the command works with the video processor (i.e. FFmpeg) directly
+* `overrideVideoArgs` Allows overriding video arguments. **Note:** It is best to ensure the command works with the process (i.e. FFmpeg) directly
+* `overrideAudioArgs` Allows overriding audio arguments. **Note:** It is best to ensure the command works with the process (i.e. FFmpeg) directly
 
 ```
 {

--- a/README.md
+++ b/README.md
@@ -39,10 +39,12 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
 * `vcodec` If you're running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option, default "libx264"
 * `audio` can be set to true to enable audio streaming from camera. To use audio ffmpeg must be compiled with --enable-libfdk-aac, see https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki, default false
 * `packetSize` If audio or video is choppy try a smaller value, set to a multiple of 188, default 1316
+* `vflip` Flips the stream vertically, default false
+* `hflip` Flips the stream horizontally, default false
 * `debug` Show the output of ffmpeg in the log, default false
-* `additionalCommandline` Allows additional of extra command line options
-* `overrideVideoArgs` Allows overriding video arguments. **Note:** It is best to ensure the command works with the process (i.e. FFmpeg) directly
-* `overrideAudioArgs` Allows overriding audio arguments. **Note:** It is best to ensure the command works with the process (i.e. FFmpeg) directly
+* `additionalCommandline` Allows additional of extra command line options to FFmpeg, for example `'-loglevel verbose'`
+* `videoFilter` Allows a custom video filter to be passed to FFmpeg via `-vf`, defaults to `scale=1280:720`
+
 
 ```
 {

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
 * `audio` can be set to true to enable audio streaming from camera. To use audio ffmpeg must be compiled with --enable-libfdk-aac, see https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki, default false
 * `packetSize` If audio or video is choppy try a smaller value, set to a multiple of 188, default 1316
 * `debug` Show the output of ffmpeg in the log, default false
+* `additionalCommandline` Allows additional of extra command line options
+* `overrideArgs` Allows overriding all arguments. **Note:** You will need to specify every option, so it is best to ensure the command works with the video processor (i.e. FFmpeg) directly
 
 ```
 {

--- a/README.md
+++ b/README.md
@@ -32,19 +32,22 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
 #### Optional Parameters
 
 * `maxStreams` is the maximum number of streams that will be generated for this camera, default 2
-* `maxWidth` is the maximum width reported to HomeKit, default 1280
-* `maxHeight` is the maximum height reported to HomeKit, default 720
-* `maxFPS` is the maximum frame rate of the stream, default 10
-* `maxBitrate` is the maximum bit rate of the stream in kbit/s, default 300
-* `vcodec` If you're running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option, default "libx264"
-* `audio` can be set to true to enable audio streaming from camera. To use audio ffmpeg must be compiled with --enable-libfdk-aac, see https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki, default false
-* `packetSize` If audio or video is choppy try a smaller value, set to a multiple of 188, default 1316
-* `vflip` Flips the stream vertically, default false
-* `hflip` Flips the stream horizontally, default false
-* `debug` Show the output of ffmpeg in the log, default false
-* `additionalCommandline` Allows additional of extra command line options to FFmpeg, for example `'-loglevel verbose'`
+* `maxWidth` is the maximum width reported to HomeKit, default `1280`
+* `maxHeight` is the maximum height reported to HomeKit, default `720`
+* `maxFPS` is the maximum frame rate of the stream, default `10`
+* `maxBitrate` is the maximum bit rate of the stream in kbit/s, default `300`
+* `vcodec` If you're running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option, default `libx264`
+* `audio` can be set to true to enable audio streaming from camera. To use audio ffmpeg must be compiled with --enable-libfdk-aac, see https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki, default `false`
+* `packetSize` If audio or video is choppy try a smaller value, set to a multiple of 188, default `1316`
+* `vflip` Flips the stream vertically, default `false`
+* `hflip` Flips the stream horizontally, default `false`
+* `mapvideo` Select the stream used for video, default `0:0`
+* `mapaudio` Select the stream used for audio, default `0:1`
 * `videoFilter` Allows a custom video filter to be passed to FFmpeg via `-vf`, defaults to `scale=1280:720`
+* `additionalCommandline` Allows additional of extra command line options to FFmpeg, for example `'-loglevel verbose'`
+* `debug` Show the output of ffmpeg in the log, default `false`
 
+A somewhat complicated example:
 
 ```
 {
@@ -61,8 +64,11 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
       	"maxFPS": 30,
       	"maxBitrate": 200,
       	"vcodec": "h264_omx",
-      	"audio": true,
+      	"audio": false,
       	"packetSize": 188,
+        "hflip": true,
+        "mapvideo": "0:2",
+        "additionalCommandline": "-loglevel debug"
       	"debug": true
       }
     }

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ A somewhat complicated example:
       	"audio": false,
       	"packetSize": 188,
         "hflip": true,
-        "mapvideo": "0:2",
         "additionalCommandline": "-loglevel debug"
       	"debug": true
       }

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -298,6 +298,7 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
         let audioSsrc = sessionInfo["audio_ssrc"];
         let vf = [];
 
+        let videoFilter = ((this.videoFilter === '') ? ('scale=' + width + ':' + height + '') : (this.videoFilter)); // empty string indicates default
         // In the case of null, skip entirely
         if (videoFilter !== null){
           vf.push(videoFilter)

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -33,8 +33,8 @@ function FFMPEG(hap, cameraConfig, log, videoProcessor) {
   this.hflip = ffmpegOpt.hflip || false;
   this.mapvideo = ffmpegOpt.mapvideo || "0:0";
   this.mapaudio = ffmpegOpt.mapaudio || "0:1";
-  this.overrideVideoArgs = ffmpegOpt.overrideVideoArgs || '';
-  this.overrideAudioArgs = ffmpegOpt.overrideAudioArgs || '';
+  // this.overrideVideoArgs = ffmpegOpt.overrideVideoArgs || '';
+  // this.overrideAudioArgs = ffmpegOpt.overrideAudioArgs || '';
   this.videoFilter = ffmpegOpt.videoFilter || ''; // null is a valid discrete value 
 
   if (!ffmpegOpt.source) {
@@ -267,7 +267,6 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
         var additionalCommandline = this.additionalCommandline;
         var mapvideo = this.mapvideo;
         var mapaudio = this.mapaudio;
-        var videoFilter = ((this.videoFilter === '') ? ('scale=' + width + ':' + height + '') : (this.videoFilter)); // empty string indicates default
 
         let videoInfo = request["video"];
         if (videoInfo) {
@@ -333,7 +332,8 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
           '&pkt_size=' + packetsize;
 
         // build required video arguments
-        fcmd += (this.overrideVideoArgs ? this.overrideVideoArgs : ffmpegVideoArgs);
+        // fcmd += (this.overrideVideoArgs ? this.overrideVideoArgs : ffmpegVideoArgs);
+        fcmd += ffmpegVideoArgs;
         fcmd += ffmpegVideoStream;
 
         // build optional audio arguments
@@ -358,7 +358,8 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
               '&localrtcpport=' + targetAudioPort +
               '&pkt_size=' + packetsize;
 
-          fcmd += (this.overrideAudioArgs ? this.overideAudioArgs : ffmpegAudioArgs);
+          // fcmd += (this.overrideAudioArgs ? this.overideAudioArgs : ffmpegAudioArgs);
+          fcmd += ffmpegAudioArgs;
           fcmd += ffmpegAudioStream;
         }
 

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -29,6 +29,7 @@ function FFMPEG(hap, cameraConfig, log, videoProcessor) {
   this.maxBitrate = ffmpegOpt.maxBitrate || 300;
   this.debug = ffmpegOpt.debug;
   this.additionalCommandline = ffmpegOpt.additionalCommandline || '-tune zerolatency';
+  this.overrideArgs = ffmpegOpt.overrideArgs || '';
 
   if (!ffmpegOpt.source) {
     throw new Error("Missing source for camera.");
@@ -287,7 +288,8 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
         let audioKey = sessionInfo["audio_srtp"];
         let audioSsrc = sessionInfo["audio_ssrc"];
 
-        let ffmpegCommand = this.ffmpegSource + ' -map 0:0' +
+        let fcmd = this.ffmpegSource + ' ';
+        let ffmpegCommand = ' -map 0:0' +
           ' -vcodec ' + vcodec +
           ' -pix_fmt yuv420p' +
           ' -r ' + fps +
@@ -328,7 +330,9 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
             '&pkt_size=' + packetsize;
         }
 
-        let ffmpeg = spawn(this.videoProcessor, ffmpegCommand.split(' '), {env: process.env});
+        fcmd += (!this.overrideArgs ? ffmpegCommand.split(' ') : this.overrideArgs);
+
+        let ffmpeg = spawn(this.videoProcessor, fcmd, {env: process.env});
         this.log("Start streaming video from " + this.name + " with " + width + "x" + height + "@" + vbitrate + "kBit");
         if(this.debug){
           console.log("ffmpeg " + ffmpegCommand);

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -31,6 +31,8 @@ function FFMPEG(hap, cameraConfig, log, videoProcessor) {
   this.additionalCommandline = ffmpegOpt.additionalCommandline || '-tune zerolatency';
   this.vflip = ffmpegOpt.vflip || false;
   this.hflip = ffmpegOpt.hflip || false;
+  this.mapvideo = ffmpegOpt.mapvideo || "0:0";
+  this.mapaudio = ffmpegOpt.mapaudio || "0:1";
   this.overrideVideoArgs = ffmpegOpt.overrideVideoArgs || '';
   this.overrideAudioArgs = ffmpegOpt.overrideAudioArgs || '';
   this.videoFilter = ffmpegOpt.videoFilter || ''; // null is a valid discrete value 
@@ -263,7 +265,9 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
         var acodec = this.acodec || 'libfdk_aac';
         var packetsize = this.packetsize || 1316; // 188 376
         var additionalCommandline = this.additionalCommandline;
-        var videoFilter = (this.videoFilter === '') ? ('scale=' + width + ':' + height + '') : (this.videoFilter); // empty string indicates default
+        var mapvideo = this.mapvideo;
+        var mapaudio = this.mapaudio;
+        var videoFilter = ((this.videoFilter === '') ? ('scale=' + width + ':' + height + '') : (this.videoFilter)); // empty string indicates default
 
         let videoInfo = request["video"];
         if (videoInfo) {
@@ -307,12 +311,12 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
 
         let fcmd = this.ffmpegSource;
 
-        let ffmpegVideoArgs = ' -map 0:0' +
+        let ffmpegVideoArgs = ' -map ' + mapvideo +
           ' -vcodec ' + vcodec +
           ' -pix_fmt yuv420p' +
           ' -r ' + fps +
           ' -f rawvideo' +
-          (vf.length > 0) ? (' -vf "' + vf.join(',') + '"') : ('') +
+          ((vf.length > 0) ? (' -vf ' + vf.join(',')) : ('')) +
           ' -b:v ' + vbitrate + 'k' +
           ' -bufsize ' + vbitrate+ 'k' +
           ' -maxrate '+ vbitrate + 'k' +
@@ -333,7 +337,7 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
 
         // build optional audio arguments
         if(this.audio) {
-          let ffmpegAudioArgs = ' -map 0:1' +
+          let ffmpegAudioArgs = ' -map ' + mapaudio +
               ' -acodec ' + acodec +
               ' -profile:a aac_eld' +
               ' -flags +global_header' +

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -33,8 +33,6 @@ function FFMPEG(hap, cameraConfig, log, videoProcessor) {
   this.hflip = ffmpegOpt.hflip || false;
   this.mapvideo = ffmpegOpt.mapvideo || "0:0";
   this.mapaudio = ffmpegOpt.mapaudio || "0:1";
-  // this.overrideVideoArgs = ffmpegOpt.overrideVideoArgs || '';
-  // this.overrideAudioArgs = ffmpegOpt.overrideAudioArgs || '';
   this.videoFilter = ffmpegOpt.videoFilter || ''; // null is a valid discrete value 
 
   if (!ffmpegOpt.source) {
@@ -332,7 +330,6 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
           '&pkt_size=' + packetsize;
 
         // build required video arguments
-        // fcmd += (this.overrideVideoArgs ? this.overrideVideoArgs : ffmpegVideoArgs);
         fcmd += ffmpegVideoArgs;
         fcmd += ffmpegVideoStream;
 
@@ -358,7 +355,6 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
               '&localrtcpport=' + targetAudioPort +
               '&pkt_size=' + packetsize;
 
-          // fcmd += (this.overrideAudioArgs ? this.overideAudioArgs : ffmpegAudioArgs);
           fcmd += ffmpegAudioArgs;
           fcmd += ffmpegAudioStream;
         }


### PR DESCRIPTION
Hello, this PR has *not* been tested thoroughly. It is in response to #258 #261 so that hardcoded arguments can be more easily overridden for testing.

The main focus of the changes are to intervene before the external process is spawned, so the arguments can be output with the overriding value (if set). Additionally, the README has been updated with information about this new parameter as well as the missing `additionalCommandLine` option.