### PR TITLE
Adding support for remapping audio and video streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
 * `vcodec` If you're running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option, default "libx264"
 * `audio` can be set to true to enable audio streaming from camera. To use audio ffmpeg must be compiled with --enable-libfdk-aac, see https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki, default false
 * `packetSize` If audio or video is choppy try a smaller value, set to a multiple of 188, default 1316
+* `mapvideo` If you want to remap which stream is used for video from the default 0:0. See ffmpeg documentation for more details to understand the map command line option.
+* `mapaudio` If you want to remap which stream is used for audio from the default 0:1. This option only makes sense if you use the audio option as well. See ffmpeg documentation for more details to understand the map command line option.
 * `debug` Show the output of ffmpeg in the log, default false
 
 ```
@@ -58,6 +60,8 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
       	"vcodec": "h264_omx",
       	"audio": true,
       	"packetSize": 188,
+      	"mapvideo": "0:0",
+      	"mapaudio": "0:1",
       	"debug": true
       }
     }

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -28,6 +28,8 @@ function FFMPEG(hap, cameraConfig, log, videoProcessor) {
   this.fps = ffmpegOpt.maxFPS || 10;
   this.maxBitrate = ffmpegOpt.maxBitrate || 300;
   this.debug = ffmpegOpt.debug;
+  this.mapvideo = ffmpegOpt.mapvideo || "0:0";
+  this.mapaudio = ffmpegOpt.mapaudio || "0:1";
   this.additionalCommandline = ffmpegOpt.additionalCommandline || '-tune zerolatency';
 
   if (!ffmpegOpt.source) {
@@ -258,6 +260,8 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
         var acodec = this.acodec || 'libfdk_aac';
         var packetsize = this.packetsize || 1316; // 188 376
         var additionalCommandline = this.additionalCommandline ;
+        var mapvideo = this.mapvideo ;
+        var mapaudio = this.mapaudio ;
 
         let videoInfo = request["video"];
         if (videoInfo) {
@@ -287,7 +291,7 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
         let audioKey = sessionInfo["audio_srtp"];
         let audioSsrc = sessionInfo["audio_ssrc"];
 
-        let ffmpegCommand = this.ffmpegSource + ' -map 0:0' +
+        let ffmpegCommand = this.ffmpegSource + ' -map ' + mapvideo +
           ' -vcodec ' + vcodec +
           ' -pix_fmt yuv420p' +
           ' -r ' + fps +
@@ -308,7 +312,7 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
           '&pkt_size=' + packetsize;
 
         if(this.audio){
-          ffmpegCommand+= ' -map 0:1' +
+          ffmpegCommand+= ' -map ' + mapaudio +
             ' -acodec ' + acodec +
             ' -profile:a aac_eld' +
             ' -flags +global_header' +


### PR DESCRIPTION
This adds support for remapping audio and video streams through two new optional configuration options, mapvideo and mapaudio. The changes are backward compatible, but it also provides a substantial amount of flexibility for people who have cameras (e.g. UniFi cameras) that don't stream audio and video streams in the way homebridge-camera-ffmpeg expects.
