### PR TITLE
Set Accessory Information

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
-var Accessory, hap, UUIDGen;
+var Accessory, Service, Characteristic, hap, UUIDGen;
 
 var FFMPEG = require('./ffmpeg').FFMPEG;
 
 module.exports = function(homebridge) {
   Accessory = homebridge.platformAccessory;
+  Service = homebridge.hap.Service;
+  Characteristic = homebridge.hap.Characteristic;
   hap = homebridge.hap;
   UUIDGen = homebridge.hap.uuid;
 
@@ -50,6 +52,21 @@ ffmpegPlatform.prototype.didFinishLaunching = function() {
 
       var uuid = UUIDGen.generate(cameraName);
       var cameraAccessory = new Accessory(cameraName, uuid, hap.Accessory.Categories.CAMERA);
+
+      var cameraAccessoryInfo = cameraAccessory.getService(Service.AccessoryInformation);
+      if (cameraConfig.manufacturer) {
+        cameraAccessoryInfo.setCharacteristic(Characteristic.Manufacturer, cameraConfig.manufacturer);
+      }
+      if (cameraConfig.model) {
+        cameraAccessoryInfo.setCharacteristic(Characteristic.Model, cameraConfig.model);
+      }
+      if (cameraConfig.serialNumber) {
+        cameraAccessoryInfo.setCharacteristic(Characteristic.SerialNumber, cameraConfig.serialNumber);
+      }
+      if (cameraConfig.firmwareRevision) {
+        cameraAccessoryInfo.setCharacteristic(Characteristic.FirmwareRevision, cameraConfig.firmwareRevision);
+      }
+
       var cameraSource = new FFMPEG(hap, cameraConfig, self.log, videoProcessor);
       cameraAccessory.configureCameraSource(cameraSource);
       configuredAccessories.push(cameraAccessory);


### PR DESCRIPTION
Added ability to set the following accessory information:
- Manufacturer
- Model
- Serial Number
- Firmware Revision

Example:
```json
{
  "platform": "Camera-ffmpeg",
  "cameras": [
    {
      "name": "Camera Name",
      "manufacturer": "ACME, Inc.",
      "model": "ABC-123",
      "serialNumber": "1234567890",
      "firmwareRevision": "1.0",
      "videoConfig": {
        "source": "-re -i rtsp://myfancy_rtsp_stream",
        "stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg",
        "maxStreams": 2,
        "maxWidth": 1280,
        "maxHeight": 720,
        "maxFPS": 30
      }
    }
  ]
}
```