### PR TITLE
Add ‘interfaceName’ optional configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,20 @@ A somewhat complicated example:
 }
 ```
 
+#### Setting a source interface, or IP address
+
+* `interfaceName` selects the IP address of a given network interface. The default is to select the first available, and that may not be the same IP address that ffmpeg will use. A mismatch will cause the iOS device to discard the video stream.
+
+```
+{
+  "platform": "Camera-ffmpeg",
+  "interfaceName": "bond0",
+  "cameras": [
+    ...
+  ]
+}
+```
+
 ## Uploading to Google Drive of Still Images ( Snapshots )
 
 This is an optional feature that will automatically store every snapshot taken to your Google Drive account as a photo.  This is very useful if you have motion sensor in the same room as the camera, as it will take a snapshot of whatever caused the motion sensor to trigger, and store the image on Google Drive and create a Picture Notification on your iOS device.

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -11,7 +11,7 @@ module.exports = {
   FFMPEG: FFMPEG
 };
 
-function FFMPEG(hap, cameraConfig, log, videoProcessor) {
+function FFMPEG(hap, cameraConfig, log, videoProcessor, interfaceName) {
   uuid = hap.uuid;
   Service = hap.Service;
   Characteristic = hap.Characteristic;
@@ -33,7 +33,8 @@ function FFMPEG(hap, cameraConfig, log, videoProcessor) {
   this.hflip = ffmpegOpt.hflip || false;
   this.mapvideo = ffmpegOpt.mapvideo || "0:0";
   this.mapaudio = ffmpegOpt.mapaudio || "0:1";
-  this.videoFilter = ffmpegOpt.videoFilter || ''; // null is a valid discrete value 
+  this.videoFilter = ffmpegOpt.videoFilter || ''; // null is a valid discrete value
+  this.interfaceName = interfaceName;
 
   if (!ffmpegOpt.source) {
     throw new Error("Missing source for camera.");
@@ -227,7 +228,7 @@ FFMPEG.prototype.prepareStream = function(request, callback) {
     sessionInfo["audio_ssrc"] = ssrc;
   }
 
-  let currentAddress = ip.address();
+  let currentAddress = ip.address(this.interfaceName);
   var addressResp = {
     address: currentAddress
   };
@@ -297,7 +298,7 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
 
         let videoFilter = ((this.videoFilter === '') ? ('scale=' + width + ':' + height + '') : (this.videoFilter)); // empty string indicates default
         // In the case of null, skip entirely
-        if (videoFilter !== null){
+        if (videoFilter !== null && videoFilter !== 'none') {
           vf.push(videoFilter)
 
           if(this.hflip)

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ ffmpegPlatform.prototype.configureAccessory = function(accessory) {
 ffmpegPlatform.prototype.didFinishLaunching = function() {
   var self = this;
   var videoProcessor = self.config.videoProcessor || 'ffmpeg';
+  var interfaceName = self.config.interfaceName;
 
   if (self.config.cameras) {
     var configuredAccessories = [];
@@ -50,7 +51,7 @@ ffmpegPlatform.prototype.didFinishLaunching = function() {
 
       var uuid = UUIDGen.generate(cameraName);
       var cameraAccessory = new Accessory(cameraName, uuid, hap.Accessory.Categories.CAMERA);
-      var cameraSource = new FFMPEG(hap, cameraConfig, self.log, videoProcessor);
+      var cameraSource = new FFMPEG(hap, cameraConfig, self.log, videoProcessor, interfaceName);
       cameraAccessory.configureCameraSource(cameraSource);
       configuredAccessories.push(cameraAccessory);
     });

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ ffmpegPlatform.prototype.configureAccessory = function(accessory) {
 ffmpegPlatform.prototype.didFinishLaunching = function() {
   var self = this;
   var videoProcessor = self.config.videoProcessor || 'ffmpeg';
-  var interfaceName = self.config.interfaceName;
+  var interfaceName = self.config.interfaceName || '';
 
   if (self.config.cameras) {
     var configuredAccessories = [];


### PR DESCRIPTION
 Useful for hosts with multiple network interfaces. See issue #317 