### PR TITLE
Add documentation on how to force OPUS codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ ffmpeg plugin for [Homebridge](https://github.com/nfarina/homebridge)
 * `maxFPS` is the maximum frame rate of the stream, default `10`
 * `maxBitrate` is the maximum bit rate of the stream in kbit/s, default `300`
 * `vcodec` If you're running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option, default `libx264`
-* `audio` can be set to true to enable audio streaming from camera. To use audio ffmpeg must be compiled with --enable-libfdk-aac, see https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki, default `false`
+* `audio` can be set to true to enable audio streaming from camera. To use audio ffmpeg must be compiled with --enable-libfdk-aac, see https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki, default `false`. Many ffmpeg binaries are not compiled with libfdk-aac, and to work around this issue, force the OPUS codec:
+  `"acodec": "libopus"`
 * `packetSize` If audio or video is choppy try a smaller value, set to a multiple of 188, default `1316`
 * `vflip` Flips the stream vertically, default `false`
 * `hflip` Flips the stream horizontally, default `false`


### PR DESCRIPTION
This may make audio functional when ffmpeg does not include libfdk-aac.