### PR TITLE
Simple fix for "Filtergraph 'scale=1280:720' was defined for video ou…

### DIFF
--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -33,7 +33,7 @@ function FFMPEG(hap, cameraConfig, log, videoProcessor, interfaceName) {
   this.hflip = ffmpegOpt.hflip || false;
   this.mapvideo = ffmpegOpt.mapvideo || "0:0";
   this.mapaudio = ffmpegOpt.mapaudio || "0:1";
-  this.videoFilter = ffmpegOpt.videoFilter || ''; // null is a valid discrete value
+  this.videoFilter = ffmpegOpt.videoFilter || null; // null is a valid discrete value
   this.interfaceName = interfaceName;
 
   if (!ffmpegOpt.source) {


### PR DESCRIPTION
…tput stream 0:0 but codec copy was selected."

setting "videoFilter": null in the config didn't help. This PR fixes it correctly.