### PR TITLE
unset loglevel debug

### DIFF
--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -361,10 +361,6 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
           fcmd += ffmpegAudioStream;
         }
 
-        if (this.debug) {
-          fcmd += ' -loglevel debug';
-        }
-
         // start the process
         let ffmpeg = spawn(this.videoProcessor, fcmd.split(' '), {env: process.env});
         this.log("Start streaming video from " + this.name + " with " + width + "x" + height + "@" + vbitrate + "kBit");


### PR DESCRIPTION
Setting debug = true in `config.json` is useful for checking various ffmpeg issues.  But sometimes it's not necessary to have full debug loglevel.  So I would remove this and then if you really need to you can add it back with `additionalCommandline`.
This fixes #316 