### PR TITLE
Add ffmpeg-for-homebridge dependency

### DIFF
--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -6,6 +6,14 @@ var fs = require('fs');
 var ip = require('ip');
 var spawn = require('child_process').spawn;
 var drive = require('./drive').drive;
+var pathToFfmpeg = require('ffmpeg-for-homebridge');
+
+if (pathToFfmpeg) {
+  child_process.spawn(pathToFfmpeg, [])
+} else {
+  // fallback, load from PATH
+  child_process.spawn('ffmpeg', [])
+}
 
 module.exports = {
   FFMPEG: FFMPEG

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "googleapis": ">=39.1.0",
+    "ffmpeg-for-homebridge": "0.0.3",
     "ip": "^1.1.3",
     "debug": "^2.2.0"
   }


### PR DESCRIPTION
## Add Dependency
* [ffmpeg for homebridge](https://github.com/homebridge/ffmpeg-for-homebridge)


@KhaosT any chance we can get this implemented to make it easier for users when using this plugin?