### PR TITLE
Fix #438 vflip not working

### DIFF
--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -173,9 +173,7 @@ FFMPEG.prototype.handleSnapshotRequest = function(request, callback) {
       break;
   }
   let vf = [];
-  this.log("this.videoFilter is " + this.videoFilter);
   let videoFilter = ((this.videoFilter === '' || this.videoFilter === null) ? ('scale=' + resolution) : (this.videoFilter)); // empty string or null indicates default
-  this.log("videoFilter is " + videoFilter)
   // In the case of null, skip entirely
   if (videoFilter !== null && videoFilter !== 'none') {
     if(this.hflip)

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -173,21 +173,24 @@ FFMPEG.prototype.handleSnapshotRequest = function(request, callback) {
       break;
   }
   let vf = [];
-  let videoFilter = ((this.videoFilter === '') ? ('scale=' + resolution) : (this.videoFilter)); // empty string indicates default
+  this.log("this.videoFilter is " + this.videoFilter);
+  let videoFilter = ((this.videoFilter === '' || this.videoFilter === null) ? ('scale=' + resolution) : (this.videoFilter)); // empty string or null indicates default
+  this.log("videoFilter is " + videoFilter)
   // In the case of null, skip entirely
   if (videoFilter !== null && videoFilter !== 'none') {
-    vf.push(videoFilter)
     if(this.hflip)
       vf.push('hflip');
 
     if(this.vflip)
       vf.push('vflip');
+
+    vf.push(videoFilter) // vflip and hflip filters must precede the scale filter to work
   }
   var imageSource = this.ffmpegImageSource !== undefined ? this.ffmpegImageSource : this.ffmpegSource;
-  let ffmpeg = spawn(this.videoProcessor, (imageSource + ' -t 1 -vf ' + vf.join(',')) : ('')) + ' -f image2 -').split(' '), {env: process.env});
+  let ffmpeg = spawn(this.videoProcessor, (imageSource + ' -t 1' + ((vf.length > 0) ? (' -vf ' + vf.join(',')) : ('')) + ' -f image2 -').split(' '), {env: process.env});
   var imageBuffer = Buffer.alloc(0);
   this.log("Snapshot from " + this.name + " at " + resolution);
-  if(this.debug) console.log('ffmpeg '+imageSource + ' -t 1 -vf scale='+ resolution + ' -f image2 -');
+  if(this.debug) console.log('ffmpeg '+imageSource + ' -t 1' + ((vf.length > 0) ? (' -vf ' + vf.join(',')) : ('')) + ' -f image2 -');
   ffmpeg.stdout.on('data', function(data) {
     imageBuffer = Buffer.concat([imageBuffer, data]);
   });
@@ -354,7 +357,7 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
         let audioSsrc = sessionInfo["audio_ssrc"];
         let vf = [];
 
-        let videoFilter = ((this.videoFilter === '') ? ('scale=' + resolution) : (this.videoFilter)); // empty string indicates default
+        let videoFilter = ((this.videoFilter === '' || this.videoFilter === null) ? ('scale=' + resolution) : (this.videoFilter)); // empty string or null indicates default
         // In the case of null, skip entirely
         if (videoFilter !== null && videoFilter !== 'none') {
           vf.push(videoFilter)

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -172,8 +172,19 @@ FFMPEG.prototype.handleSnapshotRequest = function(request, callback) {
       var resolution = width + ':' + height;
       break;
   }
+  let vf = [];
+  let videoFilter = ((this.videoFilter === '') ? ('scale=' + resolution) : (this.videoFilter)); // empty string indicates default
+  // In the case of null, skip entirely
+  if (videoFilter !== null && videoFilter !== 'none') {
+    vf.push(videoFilter)
+    if(this.hflip)
+      vf.push('hflip');
+
+    if(this.vflip)
+      vf.push('vflip');
+  }
   var imageSource = this.ffmpegImageSource !== undefined ? this.ffmpegImageSource : this.ffmpegSource;
-  let ffmpeg = spawn(this.videoProcessor, (imageSource + ' -t 1 -vf scale=' + resolution + ' -f image2 -').split(' '), {env: process.env});
+  let ffmpeg = spawn(this.videoProcessor, (imageSource + ' -t 1 -vf ' + vf.join(',')) : ('')) + ' -f image2 -').split(' '), {env: process.env});
   var imageBuffer = Buffer.alloc(0);
   this.log("Snapshot from " + this.name + " at " + resolution);
   if(this.debug) console.log('ffmpeg '+imageSource + ' -t 1 -vf scale='+ resolution + ' -f image2 -');


### PR DESCRIPTION
Fix for issue #438.

vflip and hflip filters will now act on stillImageSource snapshots and will be set when videoFilter is null as well as an empty string.