### PR TITLE
Fix #465: incorrectly registered an external accessory

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ ffmpegPlatform.prototype.didFinishLaunching = function() {
       configuredAccessories.push(cameraAccessory);
     });
 
-    self.api.publishCameraAccessories("Camera-ffmpeg", configuredAccessories);
+    self.api.publishCameraAccessories("homebridge-camera-ffmpeg", configuredAccessories);
   }
 };
 


### PR DESCRIPTION
Hey @KhaosT,  Since Homebridge v1.0.0, users have bee seeing this log.
`One of your plugins incorrectly registered an external accessory using the platform name (Camera-ffmpeg) and not the plugin identifier. Please report this to the developer!`

This is a fix for this log, so that it is registering to the correct platform name.
- This fixes homebridge issue [#2547](https://github.com/homebridge/homebridge/issues/2547).
- also fixes #465.

Thanks!