### PR TITLE
Fix #474 - copy vcodec and filters

### DIFF
--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -357,7 +357,7 @@ FFMPEG.prototype.handleStreamRequest = function(request) {
 
         let videoFilter = ((this.videoFilter === '' || this.videoFilter === null) ? ('scale=' + resolution) : (this.videoFilter)); // empty string or null indicates default
         // In the case of null, skip entirely
-        if (videoFilter !== null && videoFilter !== 'none') {
+        if (videoFilter !== null && videoFilter !== 'none' && vcodec !== 'copy') { // Filters cannot be set if the copy vcodec is used.
           vf.push(videoFilter)
 
           if(this.hflip)


### PR DESCRIPTION
Do not set video filters if the copy video codec is used as raised in issue #474.