### PR TITLE
ffmpeg-for-homebridge is not being utilized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/).
 
 
-## v0.1.20 (2020-05-05)
+## v1.0.0 (2020-05-11)
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/).
+
+
+## v0.1.20 (2020-05-05)
+
+### Breaking Changes
+
+* We are now bundling static ffmpeg binaries for Homebridge with support for audio (libfdk-aac) and hardware decoding (h264_omx) for most major platforms.  Details are [here](https://github.com/homebridge/ffmpeg-for-homebridge)
+  * And are defaulting to use the supplied version unless a different version is specified with the `videoProcessor` configuration option.
+
+### Notable Changes

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Example with manufacturer, model, serial number and firmware set:
 * `maxBitrate` is the maximum bit rate of the stream in kbit/s, default `300`
 * `preserveRatio` can be set to either `W` or `H` with respective obvious meanings, all other values have no effect
 * `vcodec` If you're running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option, default `libx264`
-* `audio` can be set to true to enable audio streaming from camera.
+* `audio` can be set to true to enable audio streaming from camera, default `false`.
 * `acodec` Default audio codec is `libfdk_aac` and is enabled in the bundled ffmpeg version.
 * `packetSize` If audio or video is choppy try a smaller value, set to a multiple of 188, default `1316`
 * `vflip` Flips the stream vertically, default `false`

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 <a href="https://www.npmjs.com/package/homebridge-camera-ffmpeg"><img title="npm version" src="https://badgen.net/npm/v/homebridge-camera-ffmpeg" ></a>
 <a href="https://www.npmjs.com/package/homebridge-camera-ffmpeg"><img title="npm downloads" src="https://badgen.net/npm/dt/homebridge-camera-ffmpeg" ></a>
 
-<p><a href="https://www.ffmpeg.org">FFmpeg</a> plugin for 
-  <a href="https://homebridge.io">Homebridge</a>. 
+<p><a href="https://www.ffmpeg.org">FFmpeg</a> plugin for
+  <a href="https://homebridge.io">Homebridge</a>.
 </p>
 
 </span>
@@ -21,7 +21,7 @@
   - Run Homebridge
   - Add extra camera accessories in Home app. The setup code is the same as homebridge.
 
-- Install via Homebridge Web UI 
+- Install via Homebridge Web UI
   - Search for `Camera FFmpeg` on the plugin screen of [config-ui-x](https://github.com/oznu/homebridge-config-ui-x) .
   - Click install.
 
@@ -90,8 +90,8 @@ Example with manufacturer, model, serial number and firmware set:
 * `maxBitrate` is the maximum bit rate of the stream in kbit/s, default `300`
 * `preserveRatio` can be set to either `W` or `H` with respective obvious meanings, all other values have no effect
 * `vcodec` If you're running on a RPi with the omx version of ffmpeg installed, you can change to the hardware accelerated video codec with this option, default `libx264`
-* `audio` can be set to true to enable audio streaming from camera. To use audio ffmpeg must be compiled with --enable-libfdk-aac, see https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki, default `false`. Many ffmpeg binaries are not compiled with libfdk-aac, and to work around this issue, force the OPUS codec:
-  `"acodec": "libopus"`
+* `audio` can be set to true to enable audio streaming from camera.
+* `acodec` Default audio codec is `libfdk_aac` and is enabled in the bundled ffmpeg version.
 * `packetSize` If audio or video is choppy try a smaller value, set to a multiple of 188, default `1316`
 * `vflip` Flips the stream vertically, default `false`
 * `hflip` Flips the stream horizontally, default `false`

--- a/index.js
+++ b/index.js
@@ -35,7 +35,6 @@ ffmpegPlatform.prototype.configureAccessory = function(accessory) {
 
 ffmpegPlatform.prototype.didFinishLaunching = function() {
   var self = this;
-  var videoProcessor = self.config.videoProcessor || 'ffmpeg';
   var interfaceName = self.config.interfaceName || '';
 
   if (self.config.cameras) {
@@ -79,7 +78,7 @@ ffmpegPlatform.prototype.didFinishLaunching = function() {
           .on('set', _Motion.bind(cameraAccessory));
       }
 
-      var cameraSource = new FFMPEG(hap, cameraConfig, self.log, videoProcessor, interfaceName);
+      var cameraSource = new FFMPEG(hap, cameraConfig, self.log, self.config.videoProcessor, interfaceName);
       cameraAccessory.configureCameraSource(cameraSource);
       configuredAccessories.push(cameraAccessory);
     });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Camera FFmpeg",
   "name": "homebridge-camera-ffmpeg",
-  "version": "0.1.19",
+  "version": "1.0.0",
   "description": "ffmpeg plugin for homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [


### PR DESCRIPTION
When debugging why I could not use the proper audio codec provided by ffmpeg-for-homebridge found that it was using the OS installed version.